### PR TITLE
Additional data visualizations

### DIFF
--- a/SceneExplorer/Properties/PublishConfiguration.xml
+++ b/SceneExplorer/Properties/PublishConfiguration.xml
@@ -30,17 +30,23 @@ Since game entities may be composed of many components, framerate drop is expect
 	<!--Link to the forum post where the mod can be discussed-->
 	<ForumLink Value="https://forum.paradoxplaza.com/forum/threads/scene-explorer.1655915/" />
 	<!--Version of the mod-->
-	<ModVersion Value="0.2.9" />
+	<ModVersion Value="0.2.10" />
 	<!--Recommended version of the base game to use the mod-->
 	<GameVersion Value="1.2.*" />
 	<!--Dependency for the mod, can be set multiple-->
 	<Dependency Id="" DisplayName="" Version="" />
 	<!--Change log for new version. Single line or multi line. Supports minimal markdown subset-->
 	<ChangeLog>
-* Fixed matrix error for smaller screens
-* Changed scaling based on screen height instead of width
-* Fixed window dragging to use full size when scaling is lower than 1.0 and properly limit to the game screen area when it was set to higher values
-* Added screen resolution change detection to recalculate internal scaling factor
+Data visualizations were added for:
+* Bezier4x3
+* Bounds3
+* float3
+* Game.Net.Segment
+* Game.Pathfind.PathElement
+* Game.Vehicles.CarNavigationLane
+* Game.Vehicles.TrainNavigationLane
+* Game.Vehicles.WatercraftNavigationLane
+* Game.Vehicles.AircraftNavigationLane
 	</ChangeLog>
 	<!--ChangeLog>
 	</ChangeLog-->

--- a/SceneExplorer/SceneExplorer.csproj
+++ b/SceneExplorer/SceneExplorer.csproj
@@ -27,8 +27,8 @@
     </PropertyGroup>
 
     <!--Imports must be after PropertyGroup block-->
-    <Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.props"/>
-    <Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.targets"/>
+    <Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.props" />
+    <Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.targets" />
 
     <ItemGroup>
         <Reference Include="Colossal.Localization">
@@ -97,8 +97,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="$(ModPropsFile)" Link="Properties\Mod.props"/>
-        <None Include="$(ModTargetsFile)" Link="Properties\Mod.targets"/>
+        <None Include="$(ModPropsFile)" Link="Properties\Mod.props" />
+        <None Include="$(ModTargetsFile)" Link="Properties\Mod.targets" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CS2-ModdingTools" Version="1.0.3" />
     </ItemGroup>
 
 </Project>

--- a/SceneExplorer/SceneExplorer.csproj
+++ b/SceneExplorer/SceneExplorer.csproj
@@ -8,11 +8,11 @@
         <!--The file where mod information which is required for publishing mod on PDX mods are stored-->
         <PublishConfigurationPath>Properties\PublishConfiguration.xml</PublishConfigurationPath>
         <LangVersion>9</LangVersion>
-        <Version>0.2.9</Version>
+        <Version>0.2.10</Version>
         <Title>Scene Explorer</Title>
         <Authors>krzychu124</Authors>
-        <AssemblyVersion>0.2.9</AssemblyVersion>
-        <FileVersion>0.2.9</FileVersion>
+        <AssemblyVersion>0.2.10</AssemblyVersion>
+        <FileVersion>0.2.10</FileVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -99,10 +99,6 @@
     <ItemGroup>
         <None Include="$(ModPropsFile)" Link="Properties\Mod.props" />
         <None Include="$(ModTargetsFile)" Link="Properties\Mod.targets" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="CS2-ModdingTools" Version="1.0.3" />
     </ItemGroup>
 
 </Project>

--- a/SceneExplorer/System/InspectObjectToolSystem.cs
+++ b/SceneExplorer/System/InspectObjectToolSystem.cs
@@ -396,7 +396,7 @@ namespace SceneExplorer.System
                     return true;
                 }
             }
-            else if (EntityManager.HasComponent<Game.Areas.Area>(entity) && EntityManager.HasBuffer<Game.Areas.Triangle>(entity))
+            else if (EntityManager.HasComponent<Area>(entity) && EntityManager.HasBuffer<Triangle>(entity))
             {
                 componentType = ComponentType.ReadOnly<Triangle>();
                 buffer = true;
@@ -443,28 +443,28 @@ namespace SceneExplorer.System
                 RenderPathElements(hovered.entity, buffer);
                 return true;
             }
-            if (managedType == typeof(Game.Vehicles.CarNavigationLane))
+            if (managedType == typeof(CarNavigationLane))
             {
                 var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
                 RenderCarNavigationLanes(hovered.entity, buffer);
                 return true;
             }
-            if (managedType == typeof(Game.Vehicles.TrainNavigationLane))
+            if (managedType == typeof(TrainNavigationLane))
             {
                 var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
                 RenderTrainNavigationLanes(hovered.entity, buffer);
                 return true;
             }
-            if (managedType == typeof(Game.Vehicles.WatercraftNavigationLane))
+            if (managedType == typeof(WatercraftNavigationLane))
             {
                 var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
                 RenderWatercraftNavigationLanes(hovered.entity, buffer);
                 return true;
             }
-            if (managedType == typeof(Game.Vehicles.AircraftNavigationLane))
+            if (managedType == typeof(AircraftNavigationLane))
             {
                 var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
@@ -520,7 +520,7 @@ namespace SceneExplorer.System
                 RenderAreaNodes(hovered.entity, hovered, buffer);
                 return true;
             }
-            if (managedType == typeof(Game.Areas.Triangle))
+            if (managedType == typeof(Triangle))
             {
                 var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);

--- a/SceneExplorer/System/InspectObjectToolSystem.cs
+++ b/SceneExplorer/System/InspectObjectToolSystem.cs
@@ -10,6 +10,7 @@ using Game.Prefabs;
 using Game.Rendering;
 using Game.Tools;
 using Game.UI.Editor;
+using Game.Vehicles;
 using SceneExplorer.ToBeReplaced;
 using SceneExplorer.ToBeReplaced.Helpers;
 using System;
@@ -20,12 +21,13 @@ using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using CarLane = Game.Net.CarLane;
+using CarLaneFlags = Game.Net.CarLaneFlags;
 using EditorContainer = Game.Tools.EditorContainer;
 using Node = Game.Net.Node;
+using PathElement = Game.Pathfind.PathElement;
 using SubArea = Game.Areas.SubArea;
 using SubLane = Game.Net.SubLane;
 using SubNet = Game.Net.SubNet;
-using PathElement = Game.Pathfind.PathElement;
 
 namespace SceneExplorer.System
 {
@@ -615,46 +617,61 @@ namespace SceneExplorer.System
 
         private void RenderPathElements(Entity entityWithPathElements, OverlayRenderSystem.Buffer buffer)
         {
-            var pathElements = EntityManager.GetBuffer<PathElement>(entityWithPathElements);
-            foreach (var pathElement in pathElements)
+            if (EntityManager.TryGetBuffer(entityWithPathElements, true, out DynamicBuffer<PathElement> pathElements))
             {
-                RenderPath(pathElement.m_Target, pathElement.m_TargetDelta, buffer);
+                foreach (var pathElement in pathElements)
+                {
+                    RenderPath(pathElement.m_Target, pathElement.m_TargetDelta, buffer);
+
+                    if (pathElements.IsCreated == false)
+                    {
+                        break;
+                    }
+                }
             }
         }
 
         private void RenderCarNavigationLanes(Entity entityWithCarNavigationLanes, OverlayRenderSystem.Buffer buffer)
         {
-            var carNavigationLanes = EntityManager.GetBuffer<Game.Vehicles.CarNavigationLane>(entityWithCarNavigationLanes);
-            foreach (var carNavigationLane in carNavigationLanes)
+            if (EntityManager.TryGetBuffer(entityWithCarNavigationLanes, true, out DynamicBuffer<CarNavigationLane> carNavigationLanes))
             {
-                RenderPath(carNavigationLane.m_Lane, carNavigationLane.m_CurvePosition, buffer);
+                foreach (var carNavigationLane in carNavigationLanes)
+                {
+                    RenderPath(carNavigationLane.m_Lane, carNavigationLane.m_CurvePosition, buffer);
+                }
             }
         }
 
         private void RenderTrainNavigationLanes(Entity entityWithTrainNavigationLanes, OverlayRenderSystem.Buffer buffer)
         {
-            var trainNavigationLanes = EntityManager.GetBuffer<Game.Vehicles.TrainNavigationLane>(entityWithTrainNavigationLanes);
-            foreach (var trainNavigationLane in trainNavigationLanes)
+            if (EntityManager.TryGetBuffer(entityWithTrainNavigationLanes, true, out DynamicBuffer<TrainNavigationLane> trainNavigationLanes))
             {
-                RenderPath(trainNavigationLane.m_Lane, trainNavigationLane.m_CurvePosition, buffer);
+                foreach (var trainNavigationLane in trainNavigationLanes)
+                {
+                    RenderPath(trainNavigationLane.m_Lane, trainNavigationLane.m_CurvePosition, buffer);
+                }
             }
         }
 
         private void RenderWatercraftNavigationLanes(Entity entityWithWatercraftNavigationLanes, OverlayRenderSystem.Buffer buffer)
         {
-            var watercraftNavigationLanes = EntityManager.GetBuffer<Game.Vehicles.WatercraftNavigationLane>(entityWithWatercraftNavigationLanes);
-            foreach (var watercraftNavigationLane in watercraftNavigationLanes)
+            if (EntityManager.TryGetBuffer(entityWithWatercraftNavigationLanes, true, out DynamicBuffer<WatercraftNavigationLane> watercraftNavigationLanes))
             {
-                RenderPath(watercraftNavigationLane.m_Lane, watercraftNavigationLane.m_CurvePosition, buffer);
+                foreach (var watercraftNavigationLane in watercraftNavigationLanes)
+                {
+                    RenderPath(watercraftNavigationLane.m_Lane, watercraftNavigationLane.m_CurvePosition, buffer);
+                }
             }
         }
 
         private void RenderAircraftNavigationLanes(Entity entityWithAircraftNavigationLanes, OverlayRenderSystem.Buffer buffer)
         {
-            var aircraftNavigationLanes = EntityManager.GetBuffer<Game.Vehicles.AircraftNavigationLane>(entityWithAircraftNavigationLanes);
-            foreach (var aircraftNavigationLane in aircraftNavigationLanes)
+            if (EntityManager.TryGetBuffer(entityWithAircraftNavigationLanes, true, out DynamicBuffer<AircraftNavigationLane> aircraftNavigationLanes))
             {
-                RenderPath(aircraftNavigationLane.m_Lane, aircraftNavigationLane.m_CurvePosition, buffer);
+                foreach (var aircraftNavigationLane in aircraftNavigationLanes)
+                {
+                    RenderPath(aircraftNavigationLane.m_Lane, aircraftNavigationLane.m_CurvePosition, buffer);
+                }
             }
         }
 

--- a/SceneExplorer/System/InspectObjectToolSystem.cs
+++ b/SceneExplorer/System/InspectObjectToolSystem.cs
@@ -1,4 +1,5 @@
-﻿using Colossal.Entities;
+﻿using Colossal;
+using Colossal.Entities;
 using Colossal.Mathematics;
 using Colossal.Serialization.Entities;
 using Game;
@@ -58,6 +59,7 @@ namespace SceneExplorer.System
         private ComponentType[] _selectedEntityComponents = Array.Empty<ComponentType>();
         private PrefabToolPanelSystem _prefabToolPanelSystem;
         private OverlayRenderSystem _overlayRenderSystem;
+        private GizmosSystem _gizmosSystem;
         private bool _eventRegistered;
         private bool startWaypointSet;
         private Game.Routes.Waypoint startWayPoint;
@@ -71,6 +73,7 @@ namespace SceneExplorer.System
             Enabled = false;
             _prefabToolPanelSystem = World.GetExistingSystemManaged<PrefabToolPanelSystem>();
             _overlayRenderSystem = World.GetOrCreateSystemManaged<OverlayRenderSystem>();
+            _gizmosSystem = World.GetOrCreateSystemManaged<GizmosSystem>();
             TryRegisterPrefabSelectedEvent();
         }
 
@@ -412,65 +415,65 @@ namespace SceneExplorer.System
         {
             if (managedType == typeof(Bezier4x3))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderCurve(hovered, buffer);
+                RenderCurve(hovered, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(Bounds3))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderBounds(hovered, buffer);
+                RenderBounds(hovered, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(float3))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderPoint(hovered, buffer);
+                RenderPoint(hovered, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(Segment))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderSegment(hovered, buffer);
+                RenderSegment(hovered, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(PathElement))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderPathElements(hovered.entity, buffer);
+                RenderPathElements(hovered.entity, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(CarNavigationLane))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderCarNavigationLanes(hovered.entity, buffer);
+                RenderCarNavigationLanes(hovered.entity, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(TrainNavigationLane))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderTrainNavigationLanes(hovered.entity, buffer);
+                RenderTrainNavigationLanes(hovered.entity, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(WatercraftNavigationLane))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderWatercraftNavigationLanes(hovered.entity, buffer);
+                RenderWatercraftNavigationLanes(hovered.entity, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(AircraftNavigationLane))
             {
-                var buffer = _overlayRenderSystem.GetBuffer(out JobHandle dependencies);
+                var gizmoBatcher = _gizmosSystem.GetGizmosBatcher(out JobHandle dependencies);
                 deps = JobHandle.CombineDependencies(inputDeps, dependencies);
-                RenderAircraftNavigationLanes(hovered.entity, buffer);
+                RenderAircraftNavigationLanes(hovered.entity, gizmoBatcher);
                 return true;
             }
             if (managedType == typeof(SubLane))
@@ -617,13 +620,13 @@ namespace SceneExplorer.System
             }
         }
 
-        private void RenderPathElements(Entity entityWithPathElements, OverlayRenderSystem.Buffer buffer)
+        private void RenderPathElements(Entity entityWithPathElements, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.TryGetBuffer(entityWithPathElements, true, out DynamicBuffer<PathElement> pathElements))
             {
                 foreach (var pathElement in pathElements)
                 {
-                    RenderPath(pathElement.m_Target, pathElement.m_TargetDelta, buffer);
+                    RenderPath(pathElement.m_Target, pathElement.m_TargetDelta, gizmoBatcher);
                 }
             }
 
@@ -631,58 +634,58 @@ namespace SceneExplorer.System
             startWaypointSet = false; 
         }
 
-        private void RenderCarNavigationLanes(Entity entityWithCarNavigationLanes, OverlayRenderSystem.Buffer buffer)
+        private void RenderCarNavigationLanes(Entity entityWithCarNavigationLanes, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.TryGetBuffer(entityWithCarNavigationLanes, true, out DynamicBuffer<CarNavigationLane> carNavigationLanes))
             {
                 foreach (var carNavigationLane in carNavigationLanes)
                 {
-                    RenderPath(carNavigationLane.m_Lane, carNavigationLane.m_CurvePosition, buffer);
+                    RenderPath(carNavigationLane.m_Lane, carNavigationLane.m_CurvePosition, gizmoBatcher);
                 }
             }
         }
 
-        private void RenderTrainNavigationLanes(Entity entityWithTrainNavigationLanes, OverlayRenderSystem.Buffer buffer)
+        private void RenderTrainNavigationLanes(Entity entityWithTrainNavigationLanes, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.TryGetBuffer(entityWithTrainNavigationLanes, true, out DynamicBuffer<TrainNavigationLane> trainNavigationLanes))
             {
                 foreach (var trainNavigationLane in trainNavigationLanes)
                 {
-                    RenderPath(trainNavigationLane.m_Lane, trainNavigationLane.m_CurvePosition, buffer);
+                    RenderPath(trainNavigationLane.m_Lane, trainNavigationLane.m_CurvePosition, gizmoBatcher);
                 }
             }
         }
 
-        private void RenderWatercraftNavigationLanes(Entity entityWithWatercraftNavigationLanes, OverlayRenderSystem.Buffer buffer)
+        private void RenderWatercraftNavigationLanes(Entity entityWithWatercraftNavigationLanes, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.TryGetBuffer(entityWithWatercraftNavigationLanes, true, out DynamicBuffer<WatercraftNavigationLane> watercraftNavigationLanes))
             {
                 foreach (var watercraftNavigationLane in watercraftNavigationLanes)
                 {
-                    RenderPath(watercraftNavigationLane.m_Lane, watercraftNavigationLane.m_CurvePosition, buffer);
+                    RenderPath(watercraftNavigationLane.m_Lane, watercraftNavigationLane.m_CurvePosition, gizmoBatcher);
                 }
             }
         }
 
-        private void RenderAircraftNavigationLanes(Entity entityWithAircraftNavigationLanes, OverlayRenderSystem.Buffer buffer)
+        private void RenderAircraftNavigationLanes(Entity entityWithAircraftNavigationLanes, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.TryGetBuffer(entityWithAircraftNavigationLanes, true, out DynamicBuffer<AircraftNavigationLane> aircraftNavigationLanes))
             {
                 foreach (var aircraftNavigationLane in aircraftNavigationLanes)
                 {
-                    RenderPath(aircraftNavigationLane.m_Lane, aircraftNavigationLane.m_CurvePosition, buffer);
+                    RenderPath(aircraftNavigationLane.m_Lane, aircraftNavigationLane.m_CurvePosition, gizmoBatcher);
                 }
             }
         }
 
-        private void RenderPath(Entity pathEntity, float2 usedInterval, OverlayRenderSystem.Buffer buffer)
+        private void RenderPath(Entity pathEntity, float2 usedInterval, GizmoBatcher gizmoBatcher)
         {
             if (EntityManager.HasComponent<Curve>(pathEntity))
             {
                 // Normal lanes components have a curve
                 var curve = EntityManager.GetComponentData<Curve>(pathEntity);
 
-                buffer.DrawCurve(Color.green, MathUtils.Cut(curve.m_Bezier, usedInterval), 0.5f);
+                gizmoBatcher.DrawBezier(MathUtils.Cut(curve.m_Bezier, usedInterval), Color.green);
             }
             // Handle transit line segments
             else if (EntityManager.TryGetComponent<Game.Routes.Waypoint>(pathEntity, out var waypoint) && EntityManager.HasComponent<Owner>(pathEntity))
@@ -695,31 +698,40 @@ namespace SceneExplorer.System
                 else 
                 {
                     startWaypointSet = false;
-                    var startSegmentIndex = startWayPoint.m_Index;
-                    var endSegmentIndex = waypoint.m_Index;
 
                     if (EntityManager.TryGetComponent<Owner>(pathEntity, out var transitLineEntity) 
                         && EntityManager.TryGetBuffer<Game.Routes.RouteSegment>(transitLineEntity.m_Owner, true, out var routeSegments))
                     {
-                        // In transit lines the end Waypoint might be beyond the end of the line.
-                        // E.g. the start Waypoint is 2, the end Waypoint is 1, and the routeSegments.Length is 4 (0,1,2,3),
-                        // therefore we need to iterate it like this: 2,3,0,1
+                        // RouteSegments are between Waypoints, e.g.:
+                        // WayPoints:      0   1   2   3
+                        // RouteSegments:    0   1   2   3
+                        // If the StartWaypoint is 1 and the EndWaypoint is 3, then we need to render segments 1 and 2.
+                        // However, the EndWaypoint might be also beyond the end of the transit line.
+                        // E.g. the StartWaypoint is 2, and the EndWaypoint is 1.
+                        // In this case we need to render segments 2, 3 and 0.
+                        var startSegmentIndex = startWayPoint.m_Index;
+                        var endSegmentIndex = waypoint.m_Index == 0 ? routeSegments.Length - 1 : waypoint.m_Index - 1;
+                        
                         var i = startSegmentIndex;
-                        do
+                        while (true)
                         {
+                            var routeSegment = routeSegments[i];
+                            if (EntityManager.HasComponent<PathElement>(routeSegment.m_Segment))
+                            {
+                                RenderPathElements(routeSegment.m_Segment, gizmoBatcher);
+                            }
+
+                            if (i == endSegmentIndex)
+                            {
+                                break;
+                            }
+
+                            i++;
                             if (i == routeSegments.Length)
                             {
                                 i = 0;
                             }
-
-                            var routeSegment = routeSegments[i];
-                            if (EntityManager.HasComponent<PathElement>(routeSegment.m_Segment))
-                            {
-                                RenderPathElements(routeSegment.m_Segment, buffer);
-                            }
-
-                            i++;
-                        } while (i != endSegmentIndex);
+                        } 
                     }
                 }
             }
@@ -729,23 +741,11 @@ namespace SceneExplorer.System
             {
                 var locationBounds = cullingInfo.m_Bounds;
 
-                var color = Color.green;
-                var width = 0.5f;
-
-                var corner1 = locationBounds.min;
-                var corner2 = new float3(locationBounds.min.x, locationBounds.min.y, locationBounds.max.z);
-                var corner5 = new float3(locationBounds.max.x, locationBounds.min.y, locationBounds.min.z);
-                var corner6 = new float3(locationBounds.max.x, locationBounds.min.y, locationBounds.max.z);
-
-                // Draw only the bottom of the bounding box
-                buffer.DrawLine(color, new Line3.Segment(corner1, corner5), width);
-                buffer.DrawLine(color, new Line3.Segment(corner5, corner6), width);
-                buffer.DrawLine(color, new Line3.Segment(corner6, corner2), width);
-                buffer.DrawLine(color, new Line3.Segment(corner2, corner1), width);
+                gizmoBatcher.DrawWireBounds((Bounds)locationBounds, Color.green);
             }
             else
             {
-                Logging.Warning($"Path segment entity {pathEntity} has no Curve or Waypoint component, thus it cannot be rendered.");
+                // The entity has no renderable component
             }
         }
 
@@ -1078,59 +1078,39 @@ namespace SceneExplorer.System
             buffer.DrawLine( outline, fill, 0f, 0f, line, width, new float2(1f));
         }
 
-        private void RenderCurve(ComponentDataRenderer.HoverData hovered, OverlayRenderSystem.Buffer buffer)
+        private void RenderCurve(ComponentDataRenderer.HoverData hovered, GizmoBatcher gizmoBatcher)
         {
             var bezierCurve = (Bezier4x3)hovered.ComponentItem.GetValueCached();
-            buffer.DrawCurve(Color.red, bezierCurve, 0.5f);
+            gizmoBatcher.DrawBezier(bezierCurve, Color.red);
         }
 
-        private void RenderPoint(ComponentDataRenderer.HoverData hovered, OverlayRenderSystem.Buffer buffer)
+        private void RenderPoint(ComponentDataRenderer.HoverData hovered, GizmoBatcher gizmoBatcher)
         {
             var point = (float3)hovered.ComponentItem.GetValueCached();
-            RenderPoint(point, buffer);
+            RenderPoint(point, gizmoBatcher);
         }
 
-        private void RenderPoint(float3 point, OverlayRenderSystem.Buffer buffer)
+        private void RenderPoint(float3 point, GizmoBatcher gizmoBatcher)
         {
-            var width = 0.2f;
-
-            buffer.DrawLine(Color.red, new Line3.Segment(new float3(point.x - 1, point.y, point.z), new float3(point.x + 1, point.y, point.z)), width);
-            buffer.DrawLine(Color.red, new Line3.Segment(new float3(point.x, point.y, point.z - 1), new float3(point.x, point.y, point.z + 1)), width);
+            var color = Color.red;
+            gizmoBatcher.DrawLine(new float3(point.x - 1, point.y, point.z), new float3(point.x + 1, point.y, point.z), color);
+            gizmoBatcher.DrawLine(new float3(point.x, point.y, point.z - 1), new float3(point.x, point.y, point.z + 1), color);
+            gizmoBatcher.DrawLine(new float3(point.x, point.y - 1, point.z), new float3(point.x, point.y + 1, point.z), color);
         }
 
-        private void RenderBounds(ComponentDataRenderer.HoverData hovered, OverlayRenderSystem.Buffer buffer)
+        private void RenderBounds(ComponentDataRenderer.HoverData hovered, GizmoBatcher gizmoBatcher)
         {
             var bounds = (Bounds3)hovered.ComponentItem.GetValueCached();
-            var color = Color.red;
-            var width = 0.2f;
-
-            var corner1 = bounds.min;
-            var corner2 = new float3(bounds.min.x, bounds.min.y, bounds.max.z);
-            var corner3 = new float3(bounds.min.x, bounds.max.y, bounds.min.z);
-            var corner4 = new float3(bounds.min.x, bounds.max.y, bounds.max.z);
-            var corner5 = new float3(bounds.max.x, bounds.min.y, bounds.min.z);
-            var corner6 = new float3(bounds.max.x, bounds.min.y, bounds.max.z);
-            var corner7 = new float3(bounds.max.x, bounds.max.y, bounds.min.z);
-            var corner8 = bounds.max;
-
-            // Unfortunatelly the OverlayRenderSystem does not support drawing vertical lines, so I only deaw the top and the bottom lines
-            buffer.DrawLine(color, new Line3.Segment(corner1, corner5), width);
-            buffer.DrawLine(color, new Line3.Segment(corner5, corner6), width);
-            buffer.DrawLine(color, new Line3.Segment(corner6, corner2), width);
-            buffer.DrawLine(color, new Line3.Segment(corner2, corner1), width);
-            buffer.DrawLine(color, new Line3.Segment(corner3, corner7), width);
-            buffer.DrawLine(color, new Line3.Segment(corner7, corner8), width);
-            buffer.DrawLine(color, new Line3.Segment(corner8, corner4), width);
-            buffer.DrawLine(color, new Line3.Segment(corner4, corner3), width);
+            gizmoBatcher.DrawWireBounds((Bounds)bounds, Color.red);
         }
 
-        private void RenderSegment(ComponentDataRenderer.HoverData hovered, OverlayRenderSystem.Buffer buffer)
+        private void RenderSegment(ComponentDataRenderer.HoverData hovered, GizmoBatcher gizmoBatcher)
         {
             Segment segment = (Segment)hovered.ComponentItem.GetValueCached();
             var color = new Color(0.9f, 0.1f, 0.1f, 0.8f);
 
-            buffer.DrawCurve(color, segment.m_Left, 0.5f);
-            buffer.DrawCurve(color, segment.m_Right, 0.5f);
+            gizmoBatcher.DrawBezier(segment.m_Left, color);
+            gizmoBatcher.DrawBezier(segment.m_Right, color);
         }
 
         private void RenderAreaNode(Game.Areas.Node node, OverlayRenderSystem.Buffer buffer)

--- a/SceneExplorer/System/InspectObjectToolSystem.cs
+++ b/SceneExplorer/System/InspectObjectToolSystem.cs
@@ -686,7 +686,7 @@ namespace SceneExplorer.System
                 takeoffLocationCompontentLookup = SystemAPI.GetComponentLookup<Game.Routes.TakeoffLocation>(true),
                 spawnLocationCompontentLookup = SystemAPI.GetComponentLookup<Game.Objects.SpawnLocation>(true),
                 cullingInfoCompontentLookup = SystemAPI.GetComponentLookup<CullingInfo>(true),
-            }.Schedule(JobHandle.CombineDependencies(Dependency, dependencies));
+            }.Schedule(JobHandle.CombineDependencies(inputDeps, dependencies));
 
             _gizmosSystem.AddGizmosBatcherWriter(jobHandle);
 

--- a/SceneExplorer/ToBeReplaced/Helpers/ComponentDataRenderer.cs
+++ b/SceneExplorer/ToBeReplaced/Helpers/ComponentDataRenderer.cs
@@ -56,7 +56,7 @@ namespace SceneExplorer.ToBeReplaced.Helpers
             if (titleHovered)
             {
                 var c = component as ComponentInfoBase;
-                lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.Component, Type = c.Type };
+                lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.Component, ComponentType = c.Type };
             }
             if (component.DetailedView)
             {
@@ -71,11 +71,11 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                     // var field = component.Fields[i];
                     if (component.Objects?.Count > i)
                     {
-                        _objectRenderer.Render(component.Objects[i], _inspector, -1, rect, out bool hovered);
-                        if (hovered)
+                        _objectRenderer.Render(component.Objects[i], _inspector, -1, rect, out var hoveredObject);
+                        if (hoveredObject != null)
                         {
                             var c = component as ComponentInfoBase;
-                            lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.ComponentItem, Type = c.Type, Index = i };
+                            lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.ComponentItem, ComponentType = c.Type, ComponentItem = hoveredObject, Index = i };
                         }
                         if (i < component.DataFields.Count - 1)
                         {
@@ -122,7 +122,7 @@ namespace SceneExplorer.ToBeReplaced.Helpers
             if (titleHovered)
             {
                 var c = component as EntityBufferComponentInfo;
-                lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.Buffer, Type = c.Type };
+                lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.Buffer, ComponentType = c.Type };
             }
 
             if (component.DetailedView)
@@ -162,11 +162,11 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                     int max = lastItem > count ? count : lastItem;
                     for (int i = firstItem; i < max; i++)
                     {
-                        _objectRenderer.Render(component.DataArray[i], _inspector, i, rect, out bool hovered);
-                        if (hovered)
+                        _objectRenderer.Render(component.DataArray[i], _inspector, i, rect, out var hoveredObject);
+                        if (hoveredObject != null)
                         {
                             var c = component as EntityBufferComponentInfo;
-                            lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.BufferItem, Type = c.Type, Index = i };
+                            lastHovered = new HoverData() { entity = entity, DataType = HoverData.HoverType.BufferItem, ComponentType = c.Type, Index = i };
                         }
                     }
                 }
@@ -255,7 +255,8 @@ namespace SceneExplorer.ToBeReplaced.Helpers
         {
             public Entity entity;
             public HoverType DataType;
-            public object Type;
+            public ComponentType ComponentType;
+            public IInspectableObject ComponentItem;
             public int Index;
 
             public enum HoverType
@@ -273,9 +274,9 @@ namespace SceneExplorer.ToBeReplaced.Helpers
     {
         private static GUILayoutOption[] _paginationButton = new GUILayoutOption[] { GUILayout.MinWidth(60), GUILayout.MaxWidth(60), GUILayout.MaxHeight(22) };
 
-        public bool Render(IInspectableObject obj, IValueInspector valueInspector, int index, Rect rect, out bool hovered)
+        public bool Render(IInspectableObject obj, IValueInspector valueInspector, int index, Rect rect, out IInspectableObject hoveredObject)
         {
-            hovered = false;
+            hoveredObject = null;
             if (obj is InspectableEntity entity)
             {
                 GUILayout.BeginHorizontal(options: null);
@@ -306,7 +307,7 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                 GUILayout.EndHorizontal();
                 if (ComponentDataRenderer.WasHovered(rect))
                 {
-                    hovered = true;
+                    hoveredObject = obj;
                 }
             }
             else if (obj is CommonInspectableObject common)
@@ -333,12 +334,18 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                 object valueCached = complex.GetValueCached();
                 GUI.enabled = valueCached != null;
                 if (CommonUI.CollapsibleHeader(
-                    $"{(!string.IsNullOrEmpty(fieldName) ? $"{fieldName}{(valueCached == null ? " <NULL>" : string.Empty)}" : $"{complex.RootType.Name} {(index >= 0 ? $"[{index}] {(!string.IsNullOrEmpty(complex.PrefabName) ? $"- {complex.PrefabName}" : string.Empty)}" : string.Empty)}")}",
-                    complex.IsActive, rect, out hovered, CommonUI.ButtonLocation.Start,
+                    $"{(!string.IsNullOrEmpty(fieldName) ? $"{fieldName} ({obj.FieldInfo?.FieldType}) {(valueCached == null ? " <NULL>" : string.Empty)}" : $"{complex.RootType.Name} {(index >= 0 ? $"[{index}] {(!string.IsNullOrEmpty(complex.PrefabName) ? $"- {complex.PrefabName}" : string.Empty)}" : string.Empty)}")}",
+                    complex.IsActive, rect, out bool headerHovered, CommonUI.ButtonLocation.Start,
                     textStyle: CommonUI.CalculateTextStyle(complex.RootType.Name, complex.IsActive), focused: obj.IsActive))
                 {
                     complex.IsActive = !complex.IsActive;
                 }
+
+                if (headerHovered)
+                {
+                    hoveredObject = obj;
+                }
+
                 GUI.enabled = true;
                 if (complex.IsActive && complex.Children != null)
                 {
@@ -348,10 +355,15 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                     GUILayout.BeginVertical(options: null);
                     for (var i = 0; i < complex.Children.Length; i++)
                     {
-                        Render(complex.Children[i], valueInspector, i, rect, out _);
+                        Render(complex.Children[i], valueInspector, i, rect, out var hoveredChildObject);
                         if (i < complex.Children.Length - 1)
                         {
                             CommonUI.DrawLine();
+                        }
+
+                        if (hoveredChildObject != null)
+                        {
+                            hoveredObject = hoveredChildObject;
                         }
                     }
                     GUILayout.EndVertical();
@@ -406,7 +418,7 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                         int max = lastItem > count ? count : lastItem;
                         for (int i = firstItem; i < max; i++)
                         {
-                            Render(iterable.DataArray[i], valueInspector, i, rect, out _);
+                            Render(iterable.DataArray[i], valueInspector, i, rect, out hoveredObject);
                         }
                     }
 

--- a/SceneExplorer/ToBeReplaced/Helpers/ComponentDataRenderer.cs
+++ b/SceneExplorer/ToBeReplaced/Helpers/ComponentDataRenderer.cs
@@ -316,7 +316,7 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                 GUILayout.Label((common.FieldInfo?.Name ?? common.ValueType.Name) + ":", UIStyle.Instance.CalculateLabelStyle(common.FieldInfo?.IsPublic ?? true), options: null);
                 GUILayout.Space(2);
                 var value = common.GetValueCached();
-                GUILayout.Label(value != null ? value.ToString() : "<NULL>", UIStyle.Instance.CalculateTextStyle((common.FieldInfo?.FieldType ?? common.ValueType)), options: null);
+                GUILayout.Label(value != null ? value.ToString() : "<NULL>", UIStyle.Instance.CalculateTextStyle(common.FieldInfo?.FieldType ?? common.ValueType), options: null);
                 GUILayout.FlexibleSpace();
                 if (common.CanInspectValue && GUILayout.Button("Preview", UIStyle.Instance.iconButton, options: null))
                 {
@@ -327,6 +327,10 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                     common.InspectorPopupRef = valueInspector.Inspect(common.GetValueCached(), common, InspectMode.Standalone);
                 }
                 GUILayout.EndHorizontal();
+                if (ComponentDataRenderer.WasHovered(rect))
+                {
+                    hoveredObject = obj;
+                }
             }
             else if (obj is ComplexObject complex)
             {
@@ -356,14 +360,14 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                     for (var i = 0; i < complex.Children.Length; i++)
                     {
                         Render(complex.Children[i], valueInspector, i, rect, out var hoveredChildObject);
-                        if (i < complex.Children.Length - 1)
-                        {
-                            CommonUI.DrawLine();
-                        }
-
                         if (hoveredChildObject != null)
                         {
                             hoveredObject = hoveredChildObject;
+                        }
+
+                        if (i < complex.Children.Length - 1)
+                        {
+                            CommonUI.DrawLine();
                         }
                     }
                     GUILayout.EndVertical();
@@ -418,7 +422,11 @@ namespace SceneExplorer.ToBeReplaced.Helpers
                         int max = lastItem > count ? count : lastItem;
                         for (int i = firstItem; i < max; i++)
                         {
-                            Render(iterable.DataArray[i], valueInspector, i, rect, out hoveredObject);
+                            Render(iterable.DataArray[i], valueInspector, i, rect, out var hoveredChildObject);
+                            if (hoveredChildObject != null)
+                            {
+                                hoveredObject = hoveredChildObject;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Hello,
It's me again! :)

I added some additional visualization features to the `InspectObjectToolSystem`, the ones which I was missing the most.
Here comes the details:

- I adapted the `ComponentDataRenderer` to support hovering over Component items (i.e. fields of Components) as well, not only over Components. 
  - Renamed the `HoverData.Type` to `ComponentType` (as it will always contain the type of the Component, even if a child item was hovered) and added a new field for a `ComponentItem` reference.
  - Replaced the `out bool hovered` argument of the `Render` method to `out IInspectableObject hoveredObject`. This lets me get the hovered ComponentItems, not only the type of the parent Component.
  - If there was a hoovered ComponentItem down the tree, then that is returned by the `Render` method at the top of the recursive call, and then it is saved in the `lastHovered.ComponentItem` field. The `lastHovered.ComponentType` behaves as before, so if there is no visualization supported for the ComponentItem, then the `InspectObjectToolSystem` can fall back to the visualization of the (parent) Component (see below).
- I modified the `ComponentDataRenderer.Render` method to also display the type of the Component items to make it more obvious for the user what is visualized, and what is not.
- I added a logic to `InspectObjectToolSystem.OnUpdate` that implements the following logic: If the `RenderByManagedType` method could visualize the ComponentItem (i.e. its type was supported), then the `OnUpdate` stops, but if it was not supported, then it falls back to the rendering of the Component (like before).
- And finally, the list of the new visualizations:
  - **Bezier4x3**: If a Component has an item (i.e. field) with the a bezier curve then it is drawn to the screen. It lets the user check the sub geometry of Components, and also provides some level of visualization for not supported Components.
  
  ![image](https://github.com/user-attachments/assets/93649fd8-e167-47e7-a18d-fde31d42d0cf)

  - **Bounds3**: Similar to bezier curve rendering, it visualizes bounding boxes. Unfortunately the used `OverlayRenderSystem` does not support drawing vertical lines, so only the top and the bottom of the box is drawn.
  
  ![image](https://github.com/user-attachments/assets/27515285-fed8-4ba3-b70a-fa30b6c65c3f)

  - **float3**: Assuming that it is a 3D location, a red cross is drawn on the map.
  
  ![image](https://github.com/user-attachments/assets/0af3a909-db09-41b6-bef3-47082f684ff2)

  - **Game.Net.Segment**: This is already a regular Component, drawn by its bezier curves. (It is a good example for testing that visualizations are now supported both on the Item and Component levels.)
  
  ![image](https://github.com/user-attachments/assets/e6b53dd4-4ea6-445e-b93f-925681e49b4a)

  - **Game.Pathfind.PathElement**: It visualizes the path (planned by the game's pathfind logic). It also supports visualization of transit lines, which are not entirely part of the PathElement buffer, but only the start and end Waypoints (i.e. the start and end transit stops). The code retrieves PathElements from the relevant segments of the transit line, and draws them recursively by `RenderPathElements`.
  
  ![image](https://github.com/user-attachments/assets/2fa8030b-1282-4b3d-93ac-b579515ebb51)

  - **Game.Vehicles.CarNavigationLane, .TrainNavigationLane, .WatercraftNavigationLane, .AircraftNavigationLane**: These are similar to the PathElement buffer, but they contain the "short term" route of the creature with additional details, like concrete sublanes.
  
  ![image](https://github.com/user-attachments/assets/6c033ab6-b9e8-4d1e-90a3-ba073cf0f5dd)


Let me know your thoughts!

I tried to test my changes as much as possible, but there is always a chance that something goes south in specific circumstances (like with my previous PR 😄). If you find something, or get negative feedback, than let me know, I'll try to respond and create a fix as soon as I can.